### PR TITLE
docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+production_config/
+plane_spotter.egg-info/
+ve/
+tests/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ get committed to git and expose your secrets.
 
 Note: you can specify alternate config paths by setting the `PLANE_SPOTTER_CONFIG_PATH` environment variable, or by specifying the value on the command line using `--config-path`.
 
+Docker
+------
+
+The application may be run in a docker container.
+
+To build the image:
+```
+docker build -t planespotter -f docker/Dockerfile .
+```
+
+Then, run the image. Make sure to mount your `production_config` directory into the container:
+```
+docker run \
+   -v $(pwd)/production_config:/usr/app/src/production_config \
+   -it planespotter run
+```
+
+The docker image has two commands that can be run:
+* `run` - will run the bot using the configuration in `production_config`
+* `sh` - will open a shell in the container for debugging purposes
+
 Backends
 =========
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-alpine
+
+WORKDIR /usr/app/src
+COPY .. /usr/app/src
+
+RUN apk upgrade && apk add chromium chromium-chromedriver
+RUN python3 -m venv ve &&  \
+    source ve/bin/activate &&  \
+    pip install -Ue .[dev]
+
+COPY ./docker/docker-entrypoint.sh /usr/bin/docker-entrypoint
+RUN chmod +x /usr/bin/docker-entrypoint
+
+VOLUME /usr/app/src/production_config
+
+ENTRYPOINT ["docker-entrypoint"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-alpine
 
 WORKDIR /usr/app/src
-COPY .. /usr/app/src
+COPY . /usr/app/src
 
 RUN apk upgrade && apk add chromium chromium-chromedriver
 RUN python3 -m venv ve &&  \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ COPY . /usr/app/src
 RUN apk upgrade && apk add chromium chromium-chromedriver
 RUN python3 -m venv ve &&  \
     source ve/bin/activate &&  \
+    pip install -U pip && \
     pip install -Ue .[dev]
 
 COPY ./docker/docker-entrypoint.sh /usr/bin/docker-entrypoint

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+source env.sh
+
+case $1 in
+  'run')
+    exit_trap() {
+        echo "exiting"
+        exit 0
+    }
+
+    trap exit_trap SIGTERM
+
+    python3 -m plane_spotter.scripts.notify
+  ;;
+  'sh')
+    sh
+  ;;
+esac

--- a/plane_spotter/twitter.py
+++ b/plane_spotter/twitter.py
@@ -38,9 +38,11 @@ class TwitterSelenium(NotificationBackend):
     def __enter__(self):
         self._log.info("starting chromedriver")
         options = Options()
-        # options.add_argument("--headless")
+        options.add_argument("--headless")
+        options.add_argument("--no-sandbox")
         options.add_argument("--start-maximized")
         options.add_argument("--incognito")
+        options.add_argument("--disable-dev-shm-usage")
         self.webdriver = webdriver.Chrome(options=options)
         self._log.info("chrome driver started")
 


### PR DESCRIPTION
adds support for running app inside docker container

Build:
```
docker build -t <tag> -f docker/Dockerfile .
```
e.g.
```
docker build -t planespotter:latest -f docker/Dockerfile .
```

Specify `production_config` mount path when running:
```
docker run -v $(pwd)/production_config:/usr/app/src/production_config -it planespotter-test:latest run
```

Options added to webdriver:
* `headless` - required when running in docker
* `no-sandbox` - container runs as root (default), this option is required when running as root (this can be changed, but honestly with the presumably low impact of this image I don't think it's a huge problem)
* `disable-dev-shm-usage` - prevents resource limit errors due to chrome running in a container

Long term, the image should _probably_ initialize a VPN connection prior to sending anything to Twitter. A good example of this would be https://github.com/haugene/docker-transmission-openvpn -- an image that runs TransmissionBT behind openvpn, requiring a vpn connection to start Transmission (we would do something similar here).

The testing process for this is a bit more challenging, so I've held off on it for now.